### PR TITLE
Fix broken build on latest arch linux version

### DIFF
--- a/tzupdate/PKGBUILD
+++ b/tzupdate/PKGBUILD
@@ -6,6 +6,7 @@ pkgrel=1
 pkgdesc='Set the system timezone based on IP geolocation'
 url=https://github.com/cdown/tzupdate
 arch=('x86_64')
+options=(!lto)
 license=('MIT')
 makedepends=('cargo')
 source=("$url/archive/refs/tags/$pkgver.tar.gz")


### PR DESCRIPTION
On latest Arch linux version the `build` process for tzupdate breaks with the following error:

```
$ makepkg -si
... skipped lines ...
   Compiling tzupdate v3.1.0 (/home/theo/projects/tzupdate-arch/src/tzupdate-3.1.0)
error: linking with `cc` failed: exit status: 1
... skipped lines ...
          /usr/bin/ld: /home/theo/projects/tzupdate-arch/src/tzupdate-3.1.0/target/release/deps/tzupdate-087f46b5d74599ea: hidden symbol `GFp_ia32cap_P' isn't defined
          /usr/bin/ld: final link failed: bad value
          collect2: error: ld returned 1 exit status

  = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
  = note: use the `-l` flag to specify native libraries to link
  = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib)

error: could not compile `tzupdate` (bin "tzupdate") due to 1 previous error
==> ERROR: A failure occurred in build().
    Aborting...
```
full [build.log](https://github.com/user-attachments/files/15926884/build.log)

This error is caused by the `-flto=auto` flag value set by `makepkg`, this PR fixes the issue by removing the `lto` build option.

### Environment

```
$ uname -a
Linux x1 5.15.160-1-MANJARO #1 SMP PREEMPT Mon May 27 02:19:36 UTC 2024 x86_64 GNU/Linux

$ makepkg --version
makepkg (pacman) 6.1.0
Copyright (c) 2006-2024 Pacman Development Team <pacman-dev@lists.archlinux.org>.
Copyright (C) 2002-2006 Judd Vinet <jvinet@zeroflux.org>.

This is free software; see the source for copying conditions.
There is NO WARRANTY, to the extent permitted by law.

$ cc --version
cc (GCC) 14.1.1 20240522
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ /usr/bin/ld --version
GNU ld (GNU Binutils) 2.42.0
Copyright (C) 2024 Free Software Foundation, Inc.
This program is free software; you may redistribute it under the terms of
the GNU General Public License version 3 or (at your option) a later version.
This program has absolutely no warranty.

$ cargo --version
cargo 1.78.0
```